### PR TITLE
Fail loudly when serializing over-long priority vectors

### DIFF
--- a/WoofWare.LiangHyphenation.Test/TestSerialization.fs
+++ b/WoofWare.LiangHyphenation.Test/TestSerialization.fs
@@ -187,6 +187,20 @@ module TestSerialization =
             let roundTrippedResult = Hyphenation.hyphenate roundTripped word
             roundTrippedResult |> shouldEqual originalResult
 
+    [<Test>]
+    let ``Serialization refuses priority vectors longer than 255`` () =
+        // A priority vector has length (pattern chars + 1) and is serialized with a single-byte length
+        // prefix (with 0 reserved to mean None). A pattern of 255+ characters would overflow that byte,
+        // silently corrupting the data on round-trip, so serialization must fail loudly instead.
+        let builder = PackedTrieBuilder ()
+        builder.AddPatterns [ System.String ('a', 300) ]
+        let trie = builder.Build ()
+
+        let exn =
+            Assert.Throws<exn> (fun () -> PackedTrieSerialization.serialize trie |> ignore<byte array>)
+
+        exn.Message.Contains "301" |> shouldEqual true
+
     [<TestCaseSource(nameof languageCases)>]
     let ``Can load language data`` (language : KnownLanguage) =
         let trie = LanguageData.load language

--- a/WoofWare.LiangHyphenation/Serialization.fs
+++ b/WoofWare.LiangHyphenation/Serialization.fs
@@ -55,6 +55,14 @@ module PackedTrieSerialization =
             match priorities with
             | None -> writer.Write 0uy // 0 length means None
             | Some arr ->
+                // The length is encoded in a single byte, with 0 reserved to mean None, so a Some vector
+                // must have length in 1..255. The builder never produces an empty Some (it skips empty
+                // patterns), so in practice only the upper bound can be hit, by an implausibly long pattern.
+                // Fail loudly rather than wrap the length and silently corrupt the data on round-trip.
+                if arr.Length < 1 || arr.Length > 255 then
+                    failwith
+                        $"Cannot serialize a pattern priority vector of length %d{arr.Length}; the serialization format supports lengths 1..255 (a priority vector has length one more than its pattern, so this corresponds to patterns of up to 254 characters)."
+
                 writer.Write (byte arr.Length)
                 writer.Write arr
 


### PR DESCRIPTION
## Problem

`PackedTrieSerialization.serializeToStream` wrote a priority vector's length as a single byte (`writer.Write (byte arr.Length)`) but then wrote the full array. A priority vector has length `pattern chars + 1`, so a pattern of ≥255 characters produces a vector of ≥256: the length byte wraps, and deserialization reads the wrong number of bytes and continues misaligned — **silent data corruption with no exception**. A length that's an exact multiple of 256 wraps to `0`, which is read back as `None`.

This only bites implausibly long patterns (≥254 chars), which never occur in real hyphenation data, but it's silent.

## Fix

The format reserves `0` to mean `None`, so a `Some` vector must encode a length in `1..255`. Serialization now `failwith`s for anything outside that range rather than wrapping it.

I chose to throw rather than widen the length encoding: a varint/int32 length would change the wire format → version bump → force regenerating the embedded `en-gb.bin`, all to support patterns that cannot realistically occur. Throwing needs no format change and fails loudly at the boundary.

(The lower-bound guard on empty `Some` is defensive — the builder skips empty patterns, so it can't currently be hit — but it documents the "0 means None" invariant.)

## Testing

- Added a regression test that builds a trie with a 300-char pattern (vector length 301) and asserts `serialize` throws. Observed it **fail** before the fix (serialize silently succeeded), then pass after.
- Full test suite passes; `fantomas --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)