### PR TITLE
Validate and normalize hyphenation exceptions

### DIFF
--- a/WoofWare.LiangHyphenation.Test/TestException.fs
+++ b/WoofWare.LiangHyphenation.Test/TestException.fs
@@ -57,6 +57,57 @@ module TestException =
 
         exn.Message.Contains "a--b" |> shouldEqual true
 
+    [<Test>]
+    let ``Digits in exceptions are rejected`` () =
+        // Digits are reserved as priority markers in the pattern language. exceptionToPattern builds a
+        // pattern *string* that AddException re-parses, so a digit treated as word content is silently
+        // reinterpreted as a priority on the way back in: "a-1b" used to compile to a pattern for the word
+        // "ab" (the '1' eaten as a priority) rather than being rejected.
+        for bad in [ "a1b" ; "a-1b" ; "1ab" ; "ab2" ; "9" ] do
+            let exn =
+                Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern bad |> ignore<string>)
+
+            exn.Message.Contains bad |> shouldEqual true
+
+    [<Test>]
+    let ``Word-boundary markers in exceptions are rejected`` () =
+        // '.' is the word-boundary marker that `hyphenate` wraps around the word. Allowing it as content
+        // injects a spurious interior boundary into the generated pattern, compiling an exception for a
+        // different (boundary-split) word.
+        for bad in [ "a.b" ; ".ab" ; "ab." ] do
+            let exn =
+                Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern bad |> ignore<string>)
+
+            exn.Message.Contains bad |> shouldEqual true
+
+    /// The set of characters that cannot appear as word content -- ASCII digits (priority markers) and the
+    /// '.' word-boundary marker -- must be rejected in any position, otherwise the string round-trip through
+    /// `Pattern.parse` silently corrupts the compiled exception. Hyphens are excluded from the generated
+    /// input so that the *only* reason to reject is the reserved character.
+    [<Test>]
+    let ``Reserved metacharacters in exceptions are rejected`` () =
+        let reserved = "0123456789."
+
+        let gen =
+            gen {
+                let! prefixLen = Gen.choose (0, 5)
+                let! suffixLen = Gen.choose (0, 5)
+                let letter = Gen.choose (int 'a', int 'z') |> Gen.map char
+                let! prefix = Gen.listOfLength prefixLen letter
+                let! suffix = Gen.listOfLength suffixLen letter
+                let! bad = Gen.elements (List.ofSeq reserved)
+                return System.String (List.toArray (prefix @ [ bad ] @ suffix))
+            }
+            |> Arb.fromGen
+
+        let property (s : string) =
+            Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern s |> ignore<string>)
+            |> ignore<exn>
+
+            true
+
+        Check.One (FsCheckConfig.config, Prop.forAll gen property)
+
     /// An exception forces breaks at exactly the positions it marks with a hyphen and suppresses every
     /// other inter-letter position, regardless of the case in which it is supplied. This is the contract
     /// of `AddException`, and it pins down both the lowercasing fix (uppercase exceptions must still take

--- a/WoofWare.LiangHyphenation.Test/TestException.fs
+++ b/WoofWare.LiangHyphenation.Test/TestException.fs
@@ -1,0 +1,113 @@
+namespace WoofWare.LiangHyphenation.Test
+
+open NUnit.Framework
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open WoofWare.LiangHyphenation
+open WoofWare.LiangHyphenation.Construction
+
+[<TestFixture>]
+module TestException =
+
+    [<Test>]
+    let ``Exception compiles to the expected pattern`` () =
+        // "uni-ver-sity" allows breaks at uni-ver and ver-sity (priority 9, odd) and suppresses
+        // every other inter-letter position (priority 8, even).
+        Pattern.exceptionToPattern "uni-ver-sity" |> shouldEqual ".u8n8i9v8e8r9s8i8t8y."
+
+    [<Test>]
+    let ``Exception without hyphens suppresses all breaks`` () =
+        // As in TeX, \hyphenation{foo} with no hyphens means "never break this word".
+        Pattern.exceptionToPattern "foo" |> shouldEqual ".f8o8o."
+
+    [<Test>]
+    let ``Exception is lowercased like TeX hyphenation entries`` () =
+        // hyphenate lowercases the word before matching, so a title-case exception that kept its case
+        // would compile to a pattern that can never match -- a silent no-op. We lowercase to match.
+        Pattern.exceptionToPattern "Uni-Ver"
+        |> shouldEqual (Pattern.exceptionToPattern "uni-ver")
+
+        Pattern.exceptionToPattern "Uni-Ver" |> shouldEqual ".u8n8i9v8e8r."
+
+    [<Test>]
+    let ``Leading hyphen is rejected`` () =
+        // A leading hyphen marks a break before the first letter, i.e. at the word boundary. Previously
+        // this silently relocated the break inside the word ("-ab" produced ".a9b.", same as "a-b").
+        let exn =
+            Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern "-ab" |> ignore<string>)
+
+        exn.Message.Contains "-ab" |> shouldEqual true
+
+    [<Test>]
+    let ``Trailing hyphen is rejected`` () =
+        // A trailing hyphen marks a break after the last letter, at the word boundary. Previously this
+        // was silently dropped ("ab-" produced ".a8b.").
+        let exn =
+            Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern "ab-" |> ignore<string>)
+
+        exn.Message.Contains "ab-" |> shouldEqual true
+
+    [<Test>]
+    let ``Consecutive hyphens are rejected`` () =
+        // A doubled hyphen marks two breaks at one inter-letter position; the second was silently
+        // collapsed into the first ("a--b" produced ".a9b.", same as "a-b").
+        let exn =
+            Assert.Throws<exn> (fun () -> Pattern.exceptionToPattern "a--b" |> ignore<string>)
+
+        exn.Message.Contains "a--b" |> shouldEqual true
+
+    /// An exception forces breaks at exactly the positions it marks with a hyphen and suppresses every
+    /// other inter-letter position, regardless of the case in which it is supplied. This is the contract
+    /// of `AddException`, and it pins down both the lowercasing fix (uppercase exceptions must still take
+    /// effect) and the positional correctness of `exceptionToPattern`.
+    [<Test>]
+    let ``Exception forces breaks at exactly its hyphen positions, case-insensitively`` () =
+        let gen =
+            gen {
+                let! length = Gen.choose (2, 12)
+                let! letters = Gen.listOfLength length (Gen.choose (int 'a', int 'z') |> Gen.map char)
+                // One flag per inter-letter position (0 .. length-2): is there a hyphen there?
+                let! markFlags = Gen.listOfLength (length - 1) (Gen.elements [ true ; false ])
+                // One flag per letter: do we supply it upper-cased?
+                let! upperFlags = Gen.listOfLength length (Gen.elements [ true ; false ])
+                return (letters, markFlags, upperFlags)
+            }
+            |> Arb.fromGen
+
+        let property (letters : char list, markFlags : bool list, upperFlags : bool list) =
+            let lettersArr = List.toArray letters
+            let word = System.String lettersArr
+
+            let marks =
+                markFlags
+                |> List.mapi (fun i m -> i, m)
+                |> List.filter snd
+                |> List.map fst
+                |> Set.ofList
+
+            // Build the exception string, inserting a hyphen after letter i when position i is marked,
+            // and upper-casing letters according to upperFlags.
+            let sb = System.Text.StringBuilder ()
+
+            for i = 0 to lettersArr.Length - 1 do
+                let c =
+                    if upperFlags.[i] then
+                        System.Char.ToUpperInvariant lettersArr.[i]
+                    else
+                        lettersArr.[i]
+
+                sb.Append c |> ignore<System.Text.StringBuilder>
+
+                if i < markFlags.Length && markFlags.[i] then
+                    sb.Append '-' |> ignore<System.Text.StringBuilder>
+
+            let trie =
+                let builder = PackedTrieBuilder ()
+                builder.AddException (sb.ToString ())
+                builder.Build ()
+
+            let points = Hyphenation.getHyphenationPoints trie word |> Set.ofArray
+            points |> shouldEqual marks
+
+        Check.One (FsCheckConfig.config, Prop.forAll gen property)

--- a/WoofWare.LiangHyphenation.Test/WoofWare.LiangHyphenation.Test.fsproj
+++ b/WoofWare.LiangHyphenation.Test/WoofWare.LiangHyphenation.Test.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="TestIntegration.fs" />
     <Compile Include="TestTrieBuilder.fs" />
     <Compile Include="TestPatternParsing.fs" />
+    <Compile Include="TestException.fs" />
     <Compile Include="TestSerialization.fs" />
     <Compile Include="TestSurface.fs" />
     <EmbeddedResource Include="Patterns/*.txt" />

--- a/WoofWare.LiangHyphenation/Pattern.fs
+++ b/WoofWare.LiangHyphenation/Pattern.fs
@@ -49,7 +49,16 @@ module Pattern =
     ///
     /// Example: "uni-ver-sity" → ".u8n8i9v8e8r9s8i8t8y."
     /// The 9s appear before 'v' and 's', allowing hyphenation at uni-ver-sity.
+    ///
+    /// The exception is lower-cased (as TeX does for \hyphenation entries), because `Hyphenation.hyphenate`
+    /// lower-cases the word before matching; an exception that kept its case would compile to a pattern that
+    /// could never match. Each hyphen must sit strictly between two letters: a leading, trailing, or doubled
+    /// hyphen marks a break at (or before, or after) a word boundary, which is meaningless, so it is rejected
+    /// rather than silently dropped or relocated.
     let exceptionToPattern (exception' : string) : string =
+        // Lower-case to match the lower-casing that `hyphenate` applies to the word.
+        let exception' = exception'.ToLowerInvariant ()
+
         let sb = StringBuilder ()
         sb.Append '.' |> ignore<StringBuilder>
 
@@ -58,7 +67,17 @@ module Pattern =
 
         for c in exception' do
             if c = '-' then
-                // The hyphen means the NEXT inter-letter position allows hyphenation
+                // The hyphen means the NEXT inter-letter position allows hyphenation. It must follow a
+                // letter (not be the first character, and not follow another hyphen): otherwise it marks
+                // a break at a word boundary, which a pattern cannot express.
+                if isFirst then
+                    failwith
+                        $"Hyphenation exception '%s{exception'}' must not begin with a hyphen: a hyphen marks a break between two letters."
+
+                if nextPriorityIs9 then
+                    failwith
+                        $"Hyphenation exception '%s{exception'}' must not contain consecutive hyphens: a hyphen marks a break between two letters."
+
                 nextPriorityIs9 <- true
             else
                 // Add priority before each letter (except the first)
@@ -71,6 +90,12 @@ module Pattern =
 
                 sb.Append c |> ignore<StringBuilder>
                 isFirst <- false
+
+        // A hyphen with no following letter marks a break after the last letter, i.e. at the trailing
+        // word boundary; reject it rather than silently dropping it.
+        if nextPriorityIs9 then
+            failwith
+                $"Hyphenation exception '%s{exception'}' must not end with a hyphen: a hyphen marks a break between two letters."
 
         sb.Append '.' |> ignore
         sb.ToString ()

--- a/WoofWare.LiangHyphenation/Pattern.fs
+++ b/WoofWare.LiangHyphenation/Pattern.fs
@@ -55,6 +55,13 @@ module Pattern =
     /// could never match. Each hyphen must sit strictly between two letters: a leading, trailing, or doubled
     /// hyphen marks a break at (or before, or after) a word boundary, which is meaningless, so it is rejected
     /// rather than silently dropped or relocated.
+    ///
+    /// The remaining characters become word content. They must not be pattern metacharacters: ASCII digits
+    /// ('0'..'9') are priority markers and '.' is the word-boundary marker. Because this function builds a
+    /// pattern *string* that is re-parsed (by `Pattern.parse`), a digit or '.' left in the content would not
+    /// survive the round-trip -- a digit would be re-read as a priority (so "a-1b" would compile a pattern
+    /// for the word "ab") and a '.' would inject a spurious interior word boundary. Such characters are
+    /// rejected rather than silently corrupting the compiled exception.
     let exceptionToPattern (exception' : string) : string =
         // Lower-case to match the lower-casing that `hyphenate` applies to the word.
         let exception' = exception'.ToLowerInvariant ()
@@ -80,6 +87,17 @@ module Pattern =
 
                 nextPriorityIs9 <- true
             else
+                // This character becomes word content, so it must not collide with a pattern metacharacter.
+                // Digits are priority markers and '.' is the word-boundary marker; either would be silently
+                // misinterpreted when the generated pattern string is re-parsed (see the doc comment).
+                if c >= '0' && c <= '9' then
+                    failwith
+                        $"Hyphenation exception '%s{exception'}' must not contain the digit '%c{c}': digits are reserved as priority markers in hyphenation patterns."
+
+                if c = '.' then
+                    failwith
+                        $"Hyphenation exception '%s{exception'}' must not contain '.': it is reserved as the word-boundary marker in hyphenation patterns."
+
                 // Add priority before each letter (except the first)
                 if not isFirst then
                     if nextPriorityIs9 then


### PR DESCRIPTION
## Problem

`Pattern.exceptionToPattern` neither validated nor normalized its input, so three classes of malformed exception were silently mishandled:

- **Leading hyphen relocates the break.** `"-ab"` → `".a9b."` — identical to `"a-b"`. The pending-hyphen flag set by the leading `-` is never consumed at the (priority-less) first letter, so it carries over to the next inter-letter position.
- **Trailing hyphen silently dropped.** `"ab-"` → `".a8b."` — the final `-` sets the flag with no following letter to consume it.
- **Case preserved ⇒ silent no-op.** `"Uni-ver"` → `".U8n8i9v..."`. `Hyphenation.hyphenate` lower-cases the word before matching (`word.ToLowerInvariant()`), so a pattern containing uppercase letters can never match. Anyone feeding a title-case exception list gets exceptions that do nothing.

## Fix

Mirror TeX's handling of `\hyphenation` entries:

- **Lower-case the exception** so it matches the lower-cased word.
- **Require each hyphen to sit strictly between two letters.** A leading, trailing, or doubled hyphen marks a break at a word boundary, which a pattern cannot express, so fail loudly rather than silently drop or relocate it — consistent with the existing "fail loudly rather than corrupt" convention elsewhere (e.g. #13).

No public API signatures change. Real TeX exception lists (e.g. `hyph-en-gb.hyp.txt`) are lower-case with interior hyphens only, so the stricter validation leaves existing data untouched.

## Tests

Added `TestException.fs` (written first; observed all five failing against the buggy code, then passing after the fix):

- Concrete reproductions of each reported case, plus "exception with no hyphens ⇒ never break".
- A **property test**: an exception forces breaks at *exactly* the positions it marks and suppresses every other inter-letter position, **regardless of supplied case** — randomly upper-casing letters and running end-to-end through `AddException` → `Build` → `getHyphenationPoints`. This pins down both the lower-casing fix and positional correctness, and would have caught the title-case no-op.

Full suite passes (including the API-surface baseline and the serialization tests that build tries from the real `hyph-en-gb.hyp.txt` exception list). Fantomas clean; build has zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)